### PR TITLE
fix: add a container class to css rule

### DIFF
--- a/base.css
+++ b/base.css
@@ -39,7 +39,7 @@
     --background-accent: var(--dracula-selection) !important;
 }
 
-.container-1D34oG.da-container {
+.container-1D34oG, .container-1D34oG.da-container {
   background-color: var(--dracula-background) !important;
 }
 


### PR DESCRIPTION
The container-1D34oG has the default background color in the friends tab, located on the homepage.
![discordPrint](https://user-images.githubusercontent.com/39111585/114557896-851c5a80-9c40-11eb-8a83-8f6c29412f34.png)
