### PR TITLE
docs(install.md): added correct URL to BetterDiscord

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-### [BetterDiscord](https://betterdiscord.net)
+### [BetterDiscord](https://betterdiscord.app)
 
 #### Installing manually
 


### PR DESCRIPTION
Install.md still points to old URL https://betterdiscord.net which returns 5XX error. The current
URL to app is https://betterdiscord.app

fix #12