### PR TITLE
fix: Change colour of the home page top bar

### DIFF
--- a/base.css
+++ b/base.css
@@ -99,6 +99,11 @@
   background-color: var(--dracula-selection) !important;
 }
 
+/* Friends Menu Header */
+.container-ZMc96U.themed-Hp1KC_{
+  background-color: var(--dracula-background) !important;
+}
+
 /* Scroll Bar */
 .theme-dark
   .scrollerThemed-2oenus.themedWithTrack-q8E3vB


### PR DESCRIPTION
This will fix the issue where the top bar in the home page is still the default discord colour. Until merged into main this can be fixed by using
```css
.container-ZMc96U.themed-Hp1KC_{
    background-color: #282a36;
}
```
in custom css on better discord