### PR TITLE
fixed the inbox and create dm popouts backgrounds

### DIFF
--- a/base.css
+++ b/base.css
@@ -216,6 +216,57 @@
   background-color: var(--dracula-background);
 }
 
+/* Create DM Popout */
+.popout-3gby1q {
+    background-color: var(--dracula-background);
+}
+/* Search field */
+.searchBarComponent-18D6hD {
+    background-color: var(--dracula-background-alt);
+}
+/* Selected friend */
+.friendSelected-3cwmD7 {
+    background-color: var(--dracula-selection);
+}
+/* Added to the list */
+.anchor-1MIwyf {
+    background-color: var(--dracula-background);
+}
+
+/* Inbox Popout */
+.header-145e10, .header-1w9Q93 {
+    background-color: var(--dracula-background);
+}
+/* Active Tab selected text */
+.active-1grPyy {
+    background-color: var(--dracula-background-alt);
+}
+/* Popout container */
+.messagesPopout-eVzQcI {
+    background-color: var(--dracula-background-alt);
+}
+/* Channel Header */
+.channelHeader-DFRX8q{
+    background-color: var(--dracula-background-alt);
+}
+/* List element */
+.container-iA3Qrz {
+    background-color: var(--dracula-background-alt);
+}
+/* Message Content */
+.messageContainer-3VTXBC {
+    background-color: var(--dracula-background);
+}
+
+/* Unread list */
+.scroller-145h9c {
+    background-color: var(--dracula-background-alt);
+}
+/* Unread messages */
+.messages-23can0 {
+    background-color: var(--dracula-background);
+}
+
 /* Syntax Highlighing in Code Blocks*/
 code {
   color: var(--dracula-foreground) !important;


### PR DESCRIPTION
Fixed the backgrounds of the popouts created by the icons on the top left on discord, namely New Group DM and Inbox.

New Group DM:
Before:
![Screenshot_20230120_113210](https://user-images.githubusercontent.com/14887349/213628519-c4490d19-51a5-4e5a-a368-81b1e83234b8.png)
After:
![Screenshot_20230120_113333](https://user-images.githubusercontent.com/14887349/213628631-a2eb6120-a494-47f0-8946-767baa9621b6.png)

Inbox (Mentions & Unreads):
Before:
![Screenshot_20230120_113739](https://user-images.githubusercontent.com/14887349/213629115-b9140942-87d6-4b2a-84a4-0f67efdef360.png)
![Screenshot_20230120_113829](https://user-images.githubusercontent.com/14887349/213629145-20fdbcd2-153c-485a-8608-68073f5b488e.png)

After:
![Screenshot_20230120_114050](https://user-images.githubusercontent.com/14887349/213629374-21dc337c-23b1-4b44-b4d3-47ab0e0e22cf.png)
![Screenshot_20230120_114121](https://user-images.githubusercontent.com/14887349/213629388-e9aa96f9-573d-417f-8ddc-4863705ceb0b.png)
